### PR TITLE
Ability to set the active sheet index upon export

### DIFF
--- a/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
+++ b/src/Maatwebsite/Excel/Writers/LaravelExcelWriter.php
@@ -467,6 +467,18 @@ class LaravelExcelWriter {
     {
         return $this->sheet;
     }
+    
+    /**
+     * Set the active sheet index
+     * @param integer $index
+     * @return LaravelExcelWriter
+     */
+    public function setActiveSheetIndex($index)
+    {
+        $this->sheet = $this->excel->setActiveSheetIndex($index);
+
+        return $this;
+    }
 
     /**
      * Set attributes


### PR DESCRIPTION
Adding that function makes it possible to do:
```php
return Excel::create('filename', function ($excel) {
    // Creating one sheet
    $excel->sheet(...);
    // Creating a second sheet
    $excel->sheet(...);
    // Selecting the first sheet so when you open the Excel file the first sheet is selected by default instead of the last one generated
    $excel->setActiveSheetIndex(0);
})->download('xlsx');
```

I've tried to use:
```php
return Excel::create('filename', function ($excel) {
    // Creating one sheet
    $excel->sheet(...);
    // Creating a second sheet
    $excel->sheet(...);
    $excel->getExcel()->setActiveSheetIndex(0);
})->download('xlsx');
```
but this doesn't work.

It only sets the property `_activeSheetIndex` properly on the **PHPExcel** object within the `excel` on the ** LaravelExcelWriter** object, here `$excel`.

I couldn't find a way to achieve this out of the box. Is there one already?